### PR TITLE
Bump css-to-react-native-transform to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "README.md"
   ],
   "dependencies": {
-    "css-to-react-native-transform": "^1.8.1",
+    "css-to-react-native-transform": "^2.0.0",
     "postcss-load-config": "^2.0.0",
     "semver": "^5.6.0"
   },


### PR DESCRIPTION
@kristerkari I hope this is okay!

I am currently having a parse issue:
`Failed to parse declaration "flex: 1 1 0%"`

Which I have a feeling got fixed by this https://github.com/styled-components/css-to-react-native/pull/44 and we just have to bring the updates upstream.

Might have to bump css-to-react-native-transform too jus to be sure https://github.com/kristerkari/css-to-react-native-transform/pull/129